### PR TITLE
Key Events

### DIFF
--- a/src/keyEvent.test.ts
+++ b/src/keyEvent.test.ts
@@ -1,0 +1,31 @@
+// ----- Imports ----- //
+
+import { Block } from '@guardian/content-api-models/v1/block';
+import Int64 from 'node-int64';
+
+import { parse } from 'keyEvent';
+
+
+// ----- Fixtures ----- //
+
+const blocks: Block[] = [
+    {
+        id: 'one',
+        bodyHtml: '',
+        bodyTextSummary: '',
+        attributes: {},
+        published: true,
+        firstPublishedDate: { dateTime: new Int64(2), iso8601: '' },
+        contributors: [],
+        elements: [],
+    }
+]
+
+
+// ----- Tests ----- //
+
+it('parses the expected number of key events', () => {
+    const keyEvents = parse(blocks);
+
+    expect(keyEvents).toBe([]);
+});

--- a/src/keyEvent.ts
+++ b/src/keyEvent.ts
@@ -1,0 +1,48 @@
+// ----- Imports ----- //
+
+import { Block } from '@guardian/content-api-models/v1/block';
+import { fromNullable, map2, withDefault } from '@guardian/types/option';
+
+import { maybeCapiDate } from 'capi';
+
+
+// ----- Types ----- //
+
+type KeyEvent = {
+    id: string;
+    title: string;
+    published: Date;
+}
+
+
+// ----- Functions ----- //
+
+const addKeyEvent =
+    (keyEvents: KeyEvent[], id: string) =>
+    (published: Date, title: string): KeyEvent[] =>
+        [ ...keyEvents, { id, published, title } ];
+
+const parse = (blocks: Block[]): KeyEvent[] =>
+    blocks.reduce<KeyEvent[]>((keyEvents, block) => {
+        if (block.attributes.keyEvent !== true) {
+            return keyEvents;
+        }
+
+        const id = block.id;
+        const published = maybeCapiDate(block.firstPublishedDate);
+        const title = fromNullable(block.attributes.title);
+        const updatedEvents = map2(addKeyEvent(keyEvents, id))(published)(title);
+
+        return withDefault(keyEvents)(updatedEvents);
+    }, []);
+
+
+// ----- Exports ----- //
+
+export type {
+    KeyEvent,
+}
+
+export {
+    parse,
+}

--- a/src/liveBlock.ts
+++ b/src/liveBlock.ts
@@ -11,7 +11,6 @@ import { maybeCapiDate } from './capi';
 
 type LiveBlock = {
     id: string;
-    isKeyEvent: boolean;
     title: Option<string>;
     firstPublished: Option<Date>;
     lastModified: Option<Date>;
@@ -24,7 +23,6 @@ type LiveBlock = {
 const parse = (block: Block): LiveBlock =>
     ({
         id: block.id,
-        isKeyEvent: block?.attributes?.keyEvent ?? false,
         title: fromNullable(block?.title),
         firstPublished: maybeCapiDate(block?.firstPublishedDate),
         lastModified: maybeCapiDate(block?.lastModifiedDate),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
         "jsx": "react",
         "moduleResolution": "node",
         "allowJs": true,
-        "rootDir": "src/",
+        "baseUrl": "src/",
         "skipLibCheck": true,
         "allowSyntheticDefaultImports": true,
         "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Why?

Adds a type `KeyEvent` and a parser to extract the key events from the list of liveblog blocks that CAPI provides. Removes the `keyEvent` field from the `LiveBlock` type in favour of this new approach.

**Note:** This change relies on [this PR](https://github.com/guardian/types/pull/14) in the types repo.

## Changes

- Updated TS baseUrl for absolute imports from `src/`
- Added `KeyEvent` type and parser
- Removed `keyEvent` field from `LiveBlock`
- Added test for key event parser
