### PR TITLE
Switch guardian/types To Master

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1386,8 +1386,8 @@
             }
         },
         "@guardian/types": {
-            "version": "github:guardian/types#40208e09c3f18078086c7c49cc92178896d4c309",
-            "from": "github:guardian/types#result",
+            "version": "github:guardian/types#5a3ab7cafa15a9a571c6a97da19fc46194c73f81",
+            "from": "github:guardian/types",
             "dev": true,
             "requires": {
                 "typescript": "^3.8.3"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "@babel/preset-react": "^7.9.4",
         "@guardian/content-api-models": "^15.9.1",
         "@guardian/src-foundations": "^1.0.1",
-        "@guardian/types": "github:guardian/types#result",
+        "@guardian/types": "github:guardian/types",
         "@storybook/addons": "^5.3.19",
         "@storybook/preset-typescript": "^3.0.0",
         "@storybook/react": "^5.3.19",


### PR DESCRIPTION
## Why?

Was previously depending on a branch that's now been merged.

## Changes

- Move `@guardian/types` dependency from `result` branch to `master`
